### PR TITLE
fix path to UI tests

### DIFF
--- a/daft-derive/tests/ui_test.rs
+++ b/daft-derive/tests/ui_test.rs
@@ -10,5 +10,5 @@
 #[test]
 fn ui() {
     let t = trybuild::TestCases::new();
-    t.pass("tests/snapshots/valid/*.rs");
+    t.pass("tests/fixtures/valid/*.rs");
 }


### PR DESCRIPTION
Hmm, it's a little strange that trybuild doesn't error out if no files were
found.
