### PR TITLE
update oxnet to 0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,12 +272,9 @@ dependencies = [
 
 [[package]]
 name = "ipnetwork"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
-dependencies = [
- "serde",
-]
+checksum = "cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -342,7 +339,8 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 [[package]]
 name = "oxnet"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/oxnet#49ee85dcd294901031c3395ee773363db1cdc289"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff7aba867c36df803039621068faf1630d3039eb999c2f6c3950d1064d4fbbdf"
 dependencies = [
  "ipnetwork",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ daft = { version = "0.1.0", path = "daft" }
 daft-derive = { version = "=0.1.0", path = "daft-derive" }
 expectorate = "1.1.0"
 newtype-uuid = "1.2.1"
-oxnet = { git = "https://github.com/oxidecomputer/oxnet" }
+oxnet = "0.1.0"
 paste = "1.0.15"
 prettyplease = "0.2.29"
 proc-macro2 = "1.0"

--- a/daft/README.md
+++ b/daft/README.md
@@ -422,7 +422,7 @@ Implementations for standard library types, all **enabled** by default:
 Implementations for third-party types, all **disabled** by default:
 
 * `uuid1`: Enable diffing for [`uuid::Uuid`](https://docs.rs/uuid/1.12.1/uuid/struct.Uuid.html).
-* `oxnet01`: Enable diffing for network types from the \[`oxnet`\] crate.
+* `oxnet01`: Enable diffing for network types from the [`oxnet`](https://docs.rs/oxnet/0.1.0/oxnet/index.html) crate.
 * `newtype-uuid1`: Enable diffing for [`newtype_uuid::TypedUuid`](https://docs.rs/newtype-uuid/1.2.1/newtype_uuid/struct.TypedUuid.html).
 
 ## Minimum supported Rust version (MSRV)


### PR DESCRIPTION
oxnet is now out on crates.io, so start using it.
