### PR TITLE
add html_root_url to daft-derive

### DIFF
--- a/daft-derive/src/lib.rs
+++ b/daft-derive/src/lib.rs
@@ -1,7 +1,9 @@
 //! Derive macro for daft (internal crate).
 //!
 //! For more information about daft, see [its documentation](https://docs.rs/daft).
-
+// Setting html_root_url allows daft's readme to have links to daft-derive. This
+// line is updated by cargo-release.
+#![doc(html_root_url = "https://docs.rs/daft-derive/0.1.0")]
 mod internals;
 
 use syn::parse_macro_input;

--- a/daft/README.md
+++ b/daft/README.md
@@ -10,8 +10,8 @@
 <!-- cargo-sync-rdme rustdoc [[ -->
 Daft is a library to perform semantic diffs of Rust data structures.
 
-Daft consists of a trait called [`Diffable`](https://docs.rs/daft/0.1.0/daft/diffable/trait.Diffable.html), along with \[a derive
-macro\]\[macro@Diffable\] by the same name. This trait represents the
+Daft consists of a trait called [`Diffable`](https://docs.rs/daft/0.1.0/daft/diffable/trait.Diffable.html), along with [a derive
+macro](https://docs.rs/daft-derive/0.1.0/daft_derive/derive.Diffable.html) by the same name. This trait represents the
 notion of a type for which two members can be simultaneously compared.
 
 ## Features
@@ -233,7 +233,7 @@ assert_eq!(
 
 #### Struct diffs
 
-For structs, the \[`Diffable`\]\[macro@Diffable\] derive macro generates
+For structs, the [`Diffable`](https://docs.rs/daft-derive/0.1.0/daft_derive/derive.Diffable.html) derive macro generates
 a diff type with a field corresponding to each field type. Each field must
 implement [`Diffable`](https://docs.rs/daft/0.1.0/daft/diffable/trait.Diffable.html).
 
@@ -378,7 +378,7 @@ impl Diffable for Identifier {
 
 ### Type and lifetime parameters
 
-If a type parameter is specified, the \[`Diffable`\]\[macro@Diffable\] derive
+If a type parameter is specified, the [`Diffable`](https://docs.rs/daft-derive/0.1.0/daft_derive/derive.Diffable.html) derive
 macro for structs normally requires that the type parameter implement
 `Diffable`. This is not required if the field is annotated with
 `#[daft(leaf)]`.

--- a/release.toml
+++ b/release.toml
@@ -8,4 +8,7 @@ tag-message = "[{{crate_name}}] version {{version}}"
 tag-name = "daft-{{version}}"
 publish = false
 dependent-version = "upgrade"
+pre-release-replacements = [
+    { file = "daft-derive/src/lib.rs", search = "^#!\\[doc\\(html_root_url = \"https://docs.rs/daft-derive/.*\"\\)\\]$", replace = "#![doc(html_root_url = \"https://docs.rs/daft-derive/{{version}}\")]", exactly = 1 },
+]
 pre-release-hook = ["just", "generate-readmes"]


### PR DESCRIPTION
This allows cargo sync-rdme to link to daft-derive.
