### PR TITLE
fix cargo-release + add docs.rs configuration

### DIFF
--- a/daft-derive/Cargo.toml
+++ b/daft-derive/Cargo.toml
@@ -38,3 +38,8 @@ license = true
 crates-io = true
 docs-rs = true
 rust-version = true
+
+[package.metadata.release]
+pre-release-replacements = [
+    { file = "src/lib.rs", search = "^#!\\[doc\\(html_root_url = \"https://docs.rs/daft-derive/.*\"\\)\\]$", replace = "#![doc(html_root_url = \"https://docs.rs/daft-derive/{{version}}\")]", exactly = 1 },
+]

--- a/daft/Cargo.toml
+++ b/daft/Cargo.toml
@@ -29,6 +29,10 @@ newtype-uuid1 = ["dep:newtype-uuid"]
 oxnet01 = ["dep:oxnet"]
 uuid1 = ["dep:uuid"]
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg=doc_cfg"]
+
 [package.metadata.cargo-sync-rdme.badge.badges]
 license = true
 crates-io = true

--- a/release.toml
+++ b/release.toml
@@ -8,7 +8,4 @@ tag-message = "[{{crate_name}}] version {{version}}"
 tag-name = "daft-{{version}}"
 publish = false
 dependent-version = "upgrade"
-pre-release-replacements = [
-    { file = "daft-derive/src/lib.rs", search = "^#!\\[doc\\(html_root_url = \"https://docs.rs/daft-derive/.*\"\\)\\]$", replace = "#![doc(html_root_url = \"https://docs.rs/daft-derive/{{version}}\")]", exactly = 1 },
-]
 pre-release-hook = ["just", "generate-readmes"]


### PR DESCRIPTION
cargo-release configuration is per-crate.

Also add `--cfg=doc_cfg` so docs.rs picks up optional feature details.
