### PR TITLE
update cargo-sync-rdme, switch to upstream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,14 +21,7 @@ jobs:
       - name: Install just and cargo-hack
         uses: taiki-e/install-action@v2
         with:
-          tool: just,cargo-hack
-      - name: Install fork of cargo-sync-rdme
-        # This is a fork of cargo-sync-rdme with a fix for
-        # https://github.com/gifnksm/cargo-sync-rdme/pull/514 included -- remove
-        # once merged upstream.
-        run: |
-          curl -LsSf https://github.com/sunshowers/cargo-sync-rdme/releases/download/v0.4.2-b.1%2Bsunshowers/cargo-sync-rdme-v0.4.2-b.1+sunshowers-x86_64-unknown-linux-gnu.tar.gz \
-            | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+          tool: just,cargo-hack,cargo-sync-rdme
       - name: Lint (clippy)
         run: just powerset clippy --all-targets
       - name: Lint (rustfmt)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
-      - name: Install just and cargo-hack
+      - name: Install just, cargo-hack, and cargo-sync-rdme
         uses: taiki-e/install-action@v2
         with:
           tool: just,cargo-hack,cargo-sync-rdme

--- a/Justfile
+++ b/Justfile
@@ -19,7 +19,6 @@ rustdoc *args:
 
 # Generate README.md files using `cargo-sync-rdme`.
 generate-readmes:
-    # Please install via cargo install --locked --git https://github.com/sunshowers/cargo-sync-rdme for now.
     cargo sync-rdme --toolchain nightly --workspace --all-features
 
 # Run cargo release in CI.


### PR DESCRIPTION
cargo-sync-rdme now includes
https://github.com/gifnksm/cargo-sync-rdme/pull/514, which means we don't need
to use my fork any more.
