### PR TITLE
Emit code on duplicate struct & field attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- The `Diffable` derive macro now produces code + errors when the only errors are duplicate struct and field attribute errors.
+
 ## [0.1.2] - 2025-03-10
 
 ### Fixed

--- a/daft-derive/src/internals/error_store.rs
+++ b/daft-derive/src/internals/error_store.rs
@@ -66,17 +66,17 @@ pub(crate) struct ErrorSink<'a, T> {
 }
 
 impl<'a, T> ErrorSink<'a, T> {
-    pub(crate) fn push(&self, error: T) {
+    pub(crate) fn push_critical(&self, error: T) {
         // This is always okay because we only briefly borrow the RefCell at any
         // time.
-        self.data.borrow_mut().push(self.id, error);
+        self.data.borrow_mut().push_critical(self.id, error);
     }
 
-    pub(crate) fn has_errors(&self) -> bool {
-        // ErrorStore::push_error propagates has_errors up the tree while
+    pub(crate) fn has_critical_errors(&self) -> bool {
+        // ErrorStore::push_critical_error propagates `has_critical_errors` up the tree while
         // writing errors, so we can just check the current ID while reading
         // this information.
-        self.data.borrow().sinks[self.id].has_errors
+        self.data.borrow().sinks[self.id].has_critical_errors
     }
 
     pub(crate) fn new_child(&self) -> ErrorSink<'a, T> {
@@ -99,14 +99,15 @@ impl<T> Default for ErrorStoreData<T> {
 }
 
 impl<T> ErrorStoreData<T> {
-    fn push(&mut self, id: usize, error: T) {
+    /// Critical errors block progress
+    fn push_critical(&mut self, id: usize, error: T) {
         self.errors.push(error);
-        self.sinks[id].has_errors = true;
+        self.sinks[id].has_critical_errors = true;
 
         // Propagate the fact that errors were encountered up the tree.
         let mut curr = id;
         while let Some(parent) = self.sinks[curr].parent {
-            self.sinks[parent].has_errors = true;
+            self.sinks[parent].has_critical_errors = true;
             curr = parent;
         }
     }
@@ -124,11 +125,11 @@ struct ErrorSinkData {
     // The parent ID in the map.
     parent: Option<usize>,
     // Whether an error was pushed via this specific context or a descendant.
-    has_errors: bool,
+    has_critical_errors: bool,
 }
 
 impl ErrorSinkData {
     fn new(parent: Option<usize>) -> Self {
-        Self { parent, has_errors: false }
+        Self { parent, has_critical_errors: false }
     }
 }

--- a/daft-derive/src/internals/error_store.rs
+++ b/daft-derive/src/internals/error_store.rs
@@ -72,6 +72,12 @@ impl<'a, T> ErrorSink<'a, T> {
         self.data.borrow_mut().push_critical(self.id, error);
     }
 
+    pub(crate) fn push_warning(&self, error: T) {
+        // This is always okay because we only briefly borrow the RefCell at any
+        // time.
+        self.data.borrow_mut().push_warning(error);
+    }
+
     pub(crate) fn has_critical_errors(&self) -> bool {
         // ErrorStore::push_critical_error propagates `has_critical_errors` up the tree while
         // writing errors, so we can just check the current ID while reading
@@ -110,6 +116,11 @@ impl<T> ErrorStoreData<T> {
             self.sinks[parent].has_critical_errors = true;
             curr = parent;
         }
+    }
+
+    /// Warning errors do not block progress
+    fn push_warning(&mut self, error: T) {
+        self.errors.push(error);
     }
 
     fn register_sink(&mut self, parent: Option<usize>) -> usize {

--- a/daft-derive/src/internals/imp.rs
+++ b/daft-derive/src/internals/imp.rs
@@ -729,7 +729,7 @@ impl FieldConfig {
                                 mode = FieldMode::Leaf;
                             }
                             FieldMode::Leaf => {
-                                errors.push_critical(meta.error(
+                                errors.push_warning(meta.error(
                                     "#[daft(leaf)] specified multiple times",
                                 ));
                             }
@@ -747,7 +747,7 @@ impl FieldConfig {
                                 mode = FieldMode::Ignore;
                             }
                             FieldMode::Ignore => {
-                                errors.push_critical(meta.error(
+                                errors.push_warning(meta.error(
                                     "#[daft(ignore)] specified multiple times",
                                 ));
                             }

--- a/daft-derive/src/internals/imp.rs
+++ b/daft-derive/src/internals/imp.rs
@@ -97,13 +97,13 @@ fn make_leaf(
                         return Ok(());
                     }
 
-                    errors.push(meta.error(format!(
+                    errors.push_critical(meta.error(format!(
                         "this is unnecessary: the Diffable \
                          implementation {} is always a leaf",
                         position.as_purpose_str(),
                     )));
                 } else {
-                    errors.push(meta.error(format!(
+                    errors.push_critical(meta.error(format!(
                         "daft attributes are not allowed {}",
                         position.as_locative_str(),
                     )));
@@ -112,7 +112,7 @@ fn make_leaf(
                 Ok(())
             });
             if let Err(err) = res {
-                errors.push(err);
+                errors.push_critical(err);
             }
         }
     }
@@ -154,7 +154,7 @@ struct BanDaftAttrsVisitor<'a> {
 impl Visit<'_> for BanDaftAttrsVisitor<'_> {
     fn visit_attribute(&mut self, attr: &Attribute) {
         if attr.path().is_ident("daft") {
-            self.errors.push(syn::Error::new_spanned(
+            self.errors.push_critical(syn::Error::new_spanned(
                 attr,
                 format!(
                     "daft attributes are not allowed {}",
@@ -528,7 +528,7 @@ impl DiffFields {
                 predicates: Default::default(),
             });
 
-        if errors.has_errors() {
+        if errors.has_critical_errors() {
             None
         } else {
             Some(Self { fields, field_configs, where_clause })
@@ -669,13 +669,13 @@ impl StructConfig {
                                     mode = StructMode::Leaf;
                                 }
                                 StructMode::Leaf => {
-                                    errors.push(meta.error(
+                                    errors.push_critical(meta.error(
                                     "#[daft(leaf)] specified multiple times",
                                 ));
                                 }
                             }
                         } else {
-                            errors.push(meta.error(
+                            errors.push_critical(meta.error(
                                 "unknown attribute \
                                  (supported attributes: leaf)",
                             ));
@@ -685,13 +685,13 @@ impl StructConfig {
                     });
 
                     if let Err(err) = res {
-                        errors.push(err);
+                        errors.push_critical(err);
                     }
                 }
             }
         }
 
-        if errors.has_errors() {
+        if errors.has_critical_errors() {
             None
         } else {
             Some(Self { mode })
@@ -729,12 +729,12 @@ impl FieldConfig {
                                 mode = FieldMode::Leaf;
                             }
                             FieldMode::Leaf => {
-                                errors.push(meta.error(
+                                errors.push_critical(meta.error(
                                     "#[daft(leaf)] specified multiple times",
                                 ));
                             }
                             _ => {
-                                errors.push(meta.error(
+                                errors.push_critical(meta.error(
                                     "#[daft(leaf)] conflicts with \
                                      other attributes",
                                 ));
@@ -747,19 +747,19 @@ impl FieldConfig {
                                 mode = FieldMode::Ignore;
                             }
                             FieldMode::Ignore => {
-                                errors.push(meta.error(
+                                errors.push_critical(meta.error(
                                     "#[daft(ignore)] specified multiple times",
                                 ));
                             }
                             _ => {
-                                errors.push(meta.error(
+                                errors.push_critical(meta.error(
                                     "#[daft(ignore)] conflicts with \
                                      other attributes",
                                 ));
                             }
                         }
                     } else {
-                        errors.push(meta.error(
+                        errors.push_critical(meta.error(
                             "unknown attribute \
                              (supported attributes: leaf, ignore)",
                         ));
@@ -769,12 +769,12 @@ impl FieldConfig {
                 });
                 // We don't return an error from our callback, but syn might.
                 if let Err(err) = res {
-                    errors.push(err);
+                    errors.push_critical(err);
                 }
             }
         }
 
-        if errors.has_errors() {
+        if errors.has_critical_errors() {
             None
         } else {
             Some(Self { mode })

--- a/daft-derive/src/internals/imp.rs
+++ b/daft-derive/src/internals/imp.rs
@@ -669,7 +669,7 @@ impl StructConfig {
                                     mode = StructMode::Leaf;
                                 }
                                 StructMode::Leaf => {
-                                    errors.push_critical(meta.error(
+                                    errors.push_warning(meta.error(
                                     "#[daft(leaf)] specified multiple times",
                                 ));
                                 }

--- a/daft-derive/tests/fixtures/invalid/output/field-specified-multiple-times.output.rs
+++ b/daft-derive/tests/fixtures/invalid/output/field-specified-multiple-times.output.rs
@@ -1,0 +1,34 @@
+struct MyStructDiff<'__daft> {
+    a: ::daft::Leaf<&'__daft i32>,
+}
+impl<'__daft> ::core::fmt::Debug for MyStructDiff<'__daft>
+where
+    ::daft::Leaf<&'__daft i32>: ::core::fmt::Debug,
+{
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        f.debug_struct(stringify!(MyStructDiff)).field(stringify!(a), &self.a).finish()
+    }
+}
+impl<'__daft> ::core::cmp::PartialEq for MyStructDiff<'__daft>
+where
+    ::daft::Leaf<&'__daft i32>: ::core::cmp::PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.a == other.a
+    }
+}
+impl<'__daft> ::core::cmp::Eq for MyStructDiff<'__daft>
+where
+    ::daft::Leaf<&'__daft i32>: ::core::cmp::Eq,
+{}
+impl ::daft::Diffable for MyStruct {
+    type Diff<'__daft> = MyStructDiff<'__daft> where Self: '__daft;
+    fn diff<'__daft>(&'__daft self, other: &'__daft Self) -> MyStructDiff<'__daft> {
+        Self::Diff {
+            a: ::daft::Leaf {
+                before: &self.a,
+                after: &other.a,
+            },
+        }
+    }
+}

--- a/daft-derive/tests/fixtures/invalid/output/struct-specified-multiple-times.output.rs
+++ b/daft-derive/tests/fixtures/invalid/output/struct-specified-multiple-times.output.rs
@@ -1,0 +1,18 @@
+impl ::daft::Diffable for MyStruct {
+    type Diff<'__daft> = ::daft::Leaf<&'__daft Self> where Self: '__daft;
+    fn diff<'__daft>(&'__daft self, other: &'__daft Self) -> Self::Diff<'__daft> {
+        ::daft::Leaf {
+            before: self,
+            after: other,
+        }
+    }
+}
+impl ::daft::Diffable for MyStruct2 {
+    type Diff<'__daft> = ::daft::Leaf<&'__daft Self> where Self: '__daft;
+    fn diff<'__daft>(&'__daft self, other: &'__daft Self) -> Self::Diff<'__daft> {
+        ::daft::Leaf {
+            before: self,
+            after: other,
+        }
+    }
+}

--- a/daft-derive/tests/fixtures/invalid/struct-unknown-attribute-multiple.rs
+++ b/daft-derive/tests/fixtures/invalid/struct-unknown-attribute-multiple.rs
@@ -1,0 +1,14 @@
+use daft::Diffable;
+
+#[derive(Diffable)]
+#[daft(ignore, leaf, leaf)]
+struct MyStruct {
+    a: i32,
+    b: String,
+}
+
+fn main() {
+    // MyStruct should still exist, even though the Diffable impl couldn't be
+    // generated.
+    let _ = MyStruct { a: 0, b: "foo".to_string() };
+}

--- a/daft-derive/tests/fixtures/invalid/struct-unknown-attribute-multiple.stderr
+++ b/daft-derive/tests/fixtures/invalid/struct-unknown-attribute-multiple.stderr
@@ -1,0 +1,11 @@
+error: unknown attribute (supported attributes: leaf)
+ --> tests/fixtures/invalid/struct-unknown-attribute-multiple.rs:4:8
+  |
+4 | #[daft(ignore, leaf, leaf)]
+  |        ^^^^^^
+
+error: #[daft(leaf)] specified multiple times
+ --> tests/fixtures/invalid/struct-unknown-attribute-multiple.rs:4:22
+  |
+4 | #[daft(ignore, leaf, leaf)]
+  |                      ^^^^


### PR DESCRIPTION
Removing duplicate attributes won't change the code emitted, we can confidently write an impl + the error. Similar to how the current macro emits an impl + errors when the `leaf` attribute is used on an enum (as it can have no effect on the generated code). 

This is an alternative to #63 that introduces the concept of "critical" and "warning" errors inside of the `ErrorSink`. The implementation of this is documented in individual ordered commits on this PR.