### PR TITLE
Impl Diffable for NonZero with 'leaf!'

### DIFF
--- a/daft/src/core_impls.rs
+++ b/daft/src/core_impls.rs
@@ -7,11 +7,12 @@ use core::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
     num::{
         NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8,
-        NonZeroU128, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8,
+        NonZeroIsize, NonZeroU128, NonZeroU16, NonZeroU32, NonZeroU64,
+        NonZeroU8, NonZeroUsize,
     },
 };
 
-leaf! { i64, i32, i16, i8, u64, u32, u16, u8, char, bool, isize, usize, NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU128, NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI128, () }
+leaf! { i64, i32, i16, i8, u64, u32, u16, u8, char, bool, isize, usize, NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU128, NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI128, NonZeroIsize, NonZeroUsize, () }
 leaf! { IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6 }
 leaf! { str }
 


### PR DESCRIPTION
I noticed that `std::num::NonZero<T>` didn't impl `Diffable`, which I would like to have for a project I'm working on. This simply uses the `leaf!{}` macro to implement `Diffable` for each of the `NonZero*` types.

I would have liked to do `impl<T: Diffable> Diffable for NonZero<T>` but that requires us to add the `T: NonZeroablePrimitive` bound to the impl (since that is a bound on the `NonZero` type itself), but we can't do that since that trait isn't stable yet.